### PR TITLE
Pipelinedb renamed max_age to sw in its latest release (0.9.6)

### DIFF
--- a/SQL/avg_temp_by_sensor.sql
+++ b/SQL/avg_temp_by_sensor.sql
@@ -1,5 +1,5 @@
 -- average temperature of sensors over the last 5 minutes by sensor name
-CREATE CONTINUOUS VIEW brewery_sensor_temps WITH (max_age = '5 minutes') AS
+CREATE CONTINUOUS VIEW brewery_sensor_temps WITH (sw = '5 minutes') AS
 SELECT payload->>'sensor' as sensor,
 AVG((payload->>'temp'::text)::numeric)
 FROM defaultsink_stream

--- a/SQL/brewery_example.sql
+++ b/SQL/brewery_example.sql
@@ -1,5 +1,5 @@
 CREATE CONTINUOUS VIEW brewery_sensor_temps
-WITH (max_age = '5 minutes')
+WITH (sw = '5 minutes')
 AS
 SELECT payload->>'sensor' as sensor,
 AVG((payload->>'temp'::text)::numeric)


### PR DESCRIPTION
Fixes #25 